### PR TITLE
string not found: TypeError: Cannot read property 'end' of undefined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,8 @@ export function getLocator ( source: string, options: Options = {} ) {
 			search = source.indexOf( search, startIndex || 0 );
 		}
 
+		if ( search === -1 ) return undefined;
+
 		let range = lineRanges[i];
 
 		const d = search >= range.end ? 1 : -1;


### PR DESCRIPTION
fix this bug:

```js
const { getLocator } = require('locate-character');

const sample = '';
const locate = getLocator(sample);

let location;

location = locate('the_unlocatable_string');
console.dir(location);
// undefined

// repeat the query
location = locate('the_unlocatable_string');
console.dir(location);
// throws TypeError: Cannot read property 'end' of undefined
// locate-character.umd.js:36
// var d = search >= range.end ? 1 : -1;

// trace:
// range == undefined
// var range = lineRanges[i];
// i == -1
```

or is this a bug in the calculation of `var i`?
maybe add .... after the `while (range)` loop?
```js
if (i < 0) i = 0;
```
workaround:
get a new locator when locate returns undefined
```js
loc = locate('needle');
if (loc === undefined) {
	locate = getLocator(code);
}
```

