### PR TITLE
change links in package.json to point GitHub

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://gitlab.com/Rich-Harris/locate-character.git"
+    "url": "git+https://github.com/Rich-Harris/locate-character.git"
   },
   "keywords": [
     "string",
@@ -33,9 +33,9 @@
   "author": "Rich Harris",
   "license": "MIT",
   "bugs": {
-    "url": "https://gitlab.com/Rich-Harris/locate-character/issues"
+    "url": "https://github.com/Rich-Harris/locate-character/issues"
   },
-  "homepage": "https://gitlab.com/Rich-Harris/locate-character#README",
+  "homepage": "https://github.com/Rich-Harris/locate-character#README",
   "devDependencies": {
     "dts-buddy": "^0.1.6",
     "typescript": "^5.1.3"


### PR DESCRIPTION
I found that the `package.json` contains links to GitLab but the repo seems to be moved to GitHub according to the README of GitLab repo.
This PR changes those links to point to GitHub.
